### PR TITLE
Optional attribute support update

### DIFF
--- a/alert_policies.tf
+++ b/alert_policies.tf
@@ -3,10 +3,10 @@ resource "google_monitoring_alert_policy" "alert_policies" {
 
   for_each = var.alert_policies
 
-  combiner = coalesce(each.value.combiner, var.alert_policy_defaults.combiner)
+  combiner = each.value.combiner
 
   display_name = coalesce(each.value.display_name, each.key)
-  enabled      = coalesce(each.value.enabled, var.alert_policy_defaults.enabled)
+  enabled      = each.value.enabled
 
 #  # threshold conditions
 #  dynamic "conditions" {
@@ -100,5 +100,5 @@ resource "google_monitoring_alert_policy" "alert_policies" {
     }
   }
 
-  notification_channels = [for channel in coalesce(each.value.notification_channels, var.alert_policy_defaults.notification_channels) : google_monitoring_notification_channel.channels[channel].id]
+  notification_channels = [for channel in each.value.notification_channels : google_monitoring_notification_channel.channels[channel].id]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,4 @@
 terraform {
-  experiments = [
-    module_variable_optional_attrs,
-  ]
-
   required_providers {
     google = {
       source  = "hashicorp/google"
@@ -10,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.3.0"
 }
 
 provider "google" {

--- a/uptime_checks.tf
+++ b/uptime_checks.tf
@@ -4,18 +4,18 @@ resource "google_monitoring_uptime_check_config" "uptime_checks" {
   for_each = var.uptime_checks
 
   display_name     = each.value.http_check == null ? "${each.value.host} TCP Check on port ${each.value.tcp_check.port}" : "${each.value.host} HTTP(S) Check"
-  period           = "${coalesce(each.value.period, var.uptime_check_defaults.period)}s"
-  selected_regions = coalesce(each.value.selected_regions, var.uptime_check_defaults.selected_regions)
-  timeout          = "${coalesce(each.value.timeout, var.uptime_check_defaults.timeout)}s"
+  period           = "${each.value.period}s"
+  selected_regions = each.value.selected_regions
+  timeout          = "${each.value.timeout}s"
 
   dynamic "http_check" {
     for_each = each.value.http_check == null ? [] : [0]
 
     content { 
-      path         = coalesce(each.value.http_check.path, var.uptime_check_defaults.http_check.path)
-      port         = coalesce(each.value.http_check.port, var.uptime_check_defaults.http_check.port)
-      use_ssl      = coalesce(each.value.http_check.use_ssl == null, var.uptime_check_defaults.http_check.use_ssl)
-      validate_ssl = (coalesce(each.value.http_check.use_ssl, var.uptime_check_defaults.http_check.use_ssl)) ? (coalesce(each.value.http_check.validate_ssl, var.uptime_check_defaults.http_check.validate_ssl)) : null
+      path         = each.value.http_check.path
+      port         = each.value.http_check.port
+      use_ssl      = each.value.http_check.use_ssl
+      validate_ssl = each.value.http_check.use_ssl ? each.value.http_check.validate_ssl : null
       mask_headers = false
       headers      = {}
     }

--- a/variables.tf
+++ b/variables.tf
@@ -2,24 +2,11 @@ variable "project" {
   type = string
 }
 
-variable "alert_policy_defaults" {
-  type = object({
-    combiner              = string
-    enabled               = bool
-    notification_channels = list(string)
-  })
-  default = {
-    combiner              = "OR"
-    enabled               = true
-    notification_channels = []
-  }
-}
-
 variable "alert_policies" {
   type = map(object({
-    combiner     = optional(string)
+    combiner     = optional(string, "OR")
     display_name = optional(string)
-    enabled      = optional(bool)
+    enabled      = optional(bool, true)
     uptime_checks = optional(map(object({
       duration          = number
       uptime_check_name = string
@@ -27,7 +14,7 @@ variable "alert_policies" {
         days_left = number
       })))
     })))
-    notification_channels = optional(list(string))
+    notification_channels = optional(list(string), [])
   }))
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -43,42 +43,17 @@ variable "notification_channels" {
   }))
 }
 
-variable "uptime_check_defaults" {
-  type = object({
-    period           = number
-    selected_regions = list(string)
-    timeout          = number
-    http_check = object({
-      path         = string
-      port         = number
-      use_ssl      = bool
-      validate_ssl = bool
-    })
-  })
-  default = {
-    period           = 60
-    selected_regions = ["USA"]
-    timeout          = 10
-    http_check = {
-      path         = "/"
-      port         = 443
-      use_ssl      = true
-      validate_ssl = true
-    }
-  }
-}
-
 variable "uptime_checks" {
   type = map(object({
     host             = string
-    period           = optional(number)
-    selected_regions = optional(list(string))
-    timeout          = optional(number)
+    period           = optional(number, 60)
+    selected_regions = optional(list(string), ["USA"])
+    timeout          = optional(number, 10)
     http_check = optional(object({
-      path         = optional(string)
-      port         = optional(number)
-      use_ssl      = optional(bool)
-      validate_ssl = optional(bool)
+      path         = optional(string, "/")
+      port         = optional(number, 443)
+      use_ssl      = optional(bool, true)
+      validate_ssl = optional(bool, true)
     }))
     tcp_check = optional(object({
       port = number


### PR DESCRIPTION
Updated optional attributes to be compatible with Terraform 1.3.0+.
Updated required version to be 1.3.0, or newer.